### PR TITLE
fix: typo on Chunked uploader > Controlling the upload page

### DIFF
--- a/pages/developer-docs/irys-sdk/chunked-uploader/controlling-the-upload.mdx
+++ b/pages/developer-docs/irys-sdk/chunked-uploader/controlling-the-upload.mdx
@@ -18,7 +18,7 @@ To resume an upload from a new uploader instance, you must use the same:
 ```js
 const irys = await getIrys();
 
-// When uploading smaller files, it's common to use they await keyword before
+// When uploading smaller files, it's common to use the await keyword before
 // uploadData() or uploadTransaction(). This causes execution to pause until the file
 // is fully uploaded. If you omit await, the upload happens in the background
 // and you can use pause and resume as needed.


### PR DESCRIPTION
## Summary

Hi, I was reading through the docs and saw this typo

- Fixed typo (use they await -> use the await)