### PR TITLE
Fix typo

### DIFF
--- a/pages/developer-docs/irys-sdk/api/getPrice.mdx
+++ b/pages/developer-docs/irys-sdk/api/getPrice.mdx
@@ -26,7 +26,7 @@ const numBytes = 1048576; // Number of bytes to check
 const priceAtomic = await irys.getPrice(numBytes);
 
 // Convert from atomic units to standard units
-const priceConverted = irys.utils.fromAtomic(numBytes);
+const priceConverted = irys.utils.fromAtomic(priceAtomic);
 
 console.log(`Uploading ${numBytes} bytes costs ${priceConverted}`);
 ```


### PR DESCRIPTION
Fixed typo in example for getPrice documentation. The 'numBytes' was being passed instead of the `priceAtomic` to the `irys.utils.fromAtomic()` function call. 